### PR TITLE
Fix calculation of updated on timestamps for Account and Slot

### DIFF
--- a/src/parallel_bigtable_client/account.rs
+++ b/src/parallel_bigtable_client/account.rs
@@ -127,7 +127,7 @@ impl From<&DbAccountInfo> for accounts::Account {
             data: account.data().to_vec(),
             write_version: account.write_version as u64,
             updated_on: Some(accounts::UnixTimestamp {
-                timestamp: SystemTime::now().elapsed().unwrap().as_secs() as i64,
+                timestamp: SystemTime::UNIX_EPOCH.elapsed().unwrap().as_millis() as i64,
             }),
         }
     }

--- a/src/parallel_bigtable_client/account.rs
+++ b/src/parallel_bigtable_client/account.rs
@@ -7,7 +7,7 @@ use {
         GeyserPluginError, ReplicaAccountInfo,
     },
     solana_sdk::pubkey::Pubkey,
-    std::time::SystemTime,
+    std::time::{Duration, SystemTime},
 };
 
 impl Eq for DbAccountInfo {}
@@ -22,6 +22,7 @@ pub struct DbAccountInfo {
     pub data: Vec<u8>,
     pub slot: u64,
     pub write_version: u64,
+    pub updated_since_epoch: Duration,
 }
 
 pub struct UpdateAccountRequest {
@@ -41,6 +42,7 @@ impl DbAccountInfo {
             data,
             slot,
             write_version: account.write_version(),
+            updated_since_epoch: SystemTime::UNIX_EPOCH.elapsed().unwrap(),
         }
     }
 }
@@ -127,7 +129,7 @@ impl From<&DbAccountInfo> for accounts::Account {
             data: account.data().to_vec(),
             write_version: account.write_version as u64,
             updated_on: Some(accounts::UnixTimestamp {
-                timestamp: SystemTime::UNIX_EPOCH.elapsed().unwrap().as_millis() as i64,
+                timestamp: account.updated_since_epoch.as_millis() as i64,
             }),
         }
     }

--- a/src/parallel_bigtable_client/slot.rs
+++ b/src/parallel_bigtable_client/slot.rs
@@ -1,28 +1,31 @@
 use {
-    crate::{parallel_bigtable_client::BufferedBigtableClient},
-    log::*,
-    prost::Message,
+    crate::parallel_bigtable_client::BufferedBigtableClient, log::*, prost::Message,
     solana_bigtable_geyser_models::models::slots,
     solana_geyser_plugin_interface::geyser_plugin_interface::GeyserPluginError,
-    std::time::SystemTime,
+    solana_geyser_plugin_interface::geyser_plugin_interface::SlotStatus, std::time::Duration,
 };
+
+pub struct UpdateSlotRequest {
+    pub slot: u64,
+    pub parent: Option<u64>,
+    pub slot_status: SlotStatus,
+    pub updated_since_epoch: Duration,
+}
 
 impl BufferedBigtableClient {
     /// Update or insert a single account
     pub async fn update_slot(
         &mut self,
-        slot: u64,
-        parent: Option<u64>,
-        status: &str,
+        request: UpdateSlotRequest,
     ) -> Result<(usize, usize), GeyserPluginError> {
         let slot_cells = vec![(
-            slot.to_string(),
+            request.slot.to_string(),
             slots::Slot {
-                slot,
-                parent,
-                status: status.to_string(),
+                slot: request.slot,
+                parent: request.parent,
+                status: request.slot_status.as_str().to_string(),
                 updated_on: Some(slots::UnixTimestamp {
-                    timestamp: SystemTime::now().elapsed().unwrap().as_secs() as i64,
+                    timestamp: request.updated_since_epoch.as_millis() as i64,
                 }),
             },
         )];


### PR DESCRIPTION
* previous code was basically calculating now()-now() resulting in 0 most of the time
* move calculation of timestamps to the earliest point where given data appears
* refactor slot updates to pass whole request down to worker instead of passing each member as argument